### PR TITLE
Create Cluster API Config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root=true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{yml,yaml}]
+indent_size=2
+indent_style=space

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+proxmox.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+kubeconfig
 proxmox.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ali Khattab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,222 @@
 # Talos Proxmox CAPI Homelab
+
+## Description
+
+This repo contains config for deploying a Kubernetes cluster based on
+[Talos](https://www.talos.dev/) using [Cluster
+API](https://github.com/kubernetes-sigs/cluster-api) (CAPI)
+
+### Motivation
+
+I want a quick, declarative way to deploy a "production-grade" Kubernetes
+cluster of multiple control plane and worker nodes. "production-grade" is used
+loosely here as my homelab is no datacenter. [Talos](https://www.talos.dev/)
+makes it easy to create a fully-functional Kubernetes cluster, providing a
+minimal OS with just enough to run Kubernetes, automatic bootstrapping of ETCD
+and ensure communication between Kubernetes components is handled over TLS
+
+[Cluster API](https://github.com/kubernetes-sigs/cluster-api) is a way to
+create clusters on various platforms, bare-metal/on-prem as well as cloud.
+Unfortunately, Sidero Labs have identified shortcomings of CAPI when it comes
+to non-cloud environments [as noted in this
+comment](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/issues/193#issuecomment-2449472526).
+However, for the time being, I will explore CAPI as my tool of choice for the
+creation/management of my homelab cluster(s)
+
+Note, this repo will only contain the config for creating the cluster(s). All
+infrastructure deployed _into_ the cluster is not included in this repo
+
+## Credits
+
+This is heavily inspired by [capi-talos-proxmox](https://github.com/une-tasse-de-cafe/capi-talos-proxmox),
+thanks to an amazing article written by [Quentin
+JOLY](https://github.com/qjoly) available at
+<https://a-cup-of.coffee/blog/talos-capi-proxmox/>
+
+The config in this repo aims to update the manifests to the latest API versions
+and provide a simple way to bootstrap a production-grade Kubernetes cluster
+inside my homelab on Proxmox
+
+## Cluster API Providers
+
+We will be using pre-configured CAPI providers:
+
+- Bootstrap Provider: [Talos bootstrap provider](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/)
+- Infrastructure Provider: [IONOS Proxmox Provider](https://github.com/ionos-cloud/cluster-api-provider-proxmox/releases/latest/)
+- IPAM Provider: [in-cluster](https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/latest/)
+- Control Plane Provider: [Talos Control Plane
+Provider](https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/)
+(CACPPT)
+
+By default, CAPI will use the latest versions. However, you could specify the
+versions in `~/.cluster-api/clusterctl.yaml` as follows:
+
+```yaml
+providers:
+- name: "talos"
+  url: "https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/download/v0.6.7/bootstrap-components.yaml"
+  type: "BootstrapProvider"
+- name: "talos"
+  url: "https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/download/v0.5.8/control-plane-components.yaml"
+  type: "ControlPlaneProvider"
+- name: "proxmox"
+  url: "https://github.com/ionos-cloud/cluster-api-provider-proxmox/releases/download/v0.6.2/infrastructure-components.yaml"
+  type: "InfrastructureProvider"
+```
+
+## Prerequisites
+
+A few things need to be installed/available to start. These are:
+
+- A Proxmox instance
+  - this doesn't have to be a cluster. It has been tested on a
+  standalone server
+- Talos ISO from <https://factory.talos.dev/>
+  - This needs to be uploaded to Proxmox so we can create VMs with this image
+  - This needs to have the Qemu Guest Agent installed
+- [clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [kind](https://kind.sigs.k8s.io/)
+  - Docker or Podman are required to be installed locally for this
+- [yq](https://github.com/mikefarah/yq)
+
+### Template VM
+
+A VM also has to be created in Proxmox ahead of time. Currently this is done
+manually. However, this could be automated with the Proxmox APIs. This VM will
+be used as a template for both control plane and worker nodes. The CAPMOX
+provider will resize the VMs, so the template config doesn't matter _too_ much.
+Create the VM as follows:
+
+- VM ID of `125` (else, you can adapt the manifests in this repo)
+- OS ISO from prerequisites
+- __Qemu Agent enabled__
+- 20GB disk space
+- 1 CPU core and 1 CPU socket
+- 2048 MiB memory
+- default bridge network (usually `vmbr0`)
+
+This VM does not need to be started
+
+### Proxmox credentials
+
+We need to generate a user/token in Proxmox to allow us to authenticate with the
+Proxmox APIs to provision VMs via Cluster API. This can be done in the Proxmox
+__host__ shell (i.e. not a VM shell):
+
+```bash
+pveum user add capmox@pve
+pveum aclmod / -user capmox@pve -role Administrator
+pveum user token add capmox@pve capi -privsep 0
+```
+
+Make a note of the token as this won't be shown again.
+
+Create a `proxmox.env` file from the example file:
+
+```bash
+cp proxmox.env.example proxmox.env
+```
+
+Populate the token that was just obtained, along with the IP of the Proxmox machine
+
+> [!CAUTION]
+>
+> Currently, this uses __FULL ADMINISTRATOR__ privileges.
+> `PVEVMAdmin` _may_ have previously worked, but it seems like it has some missing
+> permissions as of PVE v9. To configure the Proxmox user properly, see the
+> official IONOS CAPMOX docs:
+> [Proxmox RBAC with least privileges](https://github.com/ionos-cloud/cluster-api-provider-proxmox/blob/main/docs/advanced-setups.md#proxmox-rbac-with-least-privileges)
+
+## Usage
+
+### Create management and workload clusters
+
+Assuming all the prerequisite components have been installed/configured, we can
+now provision the management cluster and then our workload cluster. A small bash
+script has been written to perform both parts in sequence. This can be executed
+as:
+
+```bash
+bash scripts/init.sh
+```
+
+This will take a few minutes
+
+> [!TIP]
+>
+> You can watch the progress with:
+>
+> ```bash
+> watch kubectl get proxmoxcluster,cluster,taloscontrolplane,ProxmoxMachineTemplate,machine,proxmoxmachine,TalosConfigTemplate
+> ```
+>
+> assuming the `watch` utility has been installed on your OS
+>
+> You can also view the logs at:
+>
+> ```bash
+> kubectl stern -n capmox-system capmox-controller-manager
+> ```
+>
+> Assuming [stern](https://github.com/stern/stern) has been installed as a
+> `kubectl` plugin. See [krew](https://krew.sigs.k8s.io/) docs on more info
+> regarding `kubectl` plugins
+
+After all nodes (`machine.cluster.x-k8s.io`) are showing as `READY` and
+`AVAILABLE` being `true`, we now have our workload cluster up and running and
+ready to go! 🎉
+
+### Get Kubeconfig
+
+Use the script [get-kubeconfig.sh](./scripts/get-kubeconfig.sh) to retrieve the
+`kubeconfig` of the _workload_ cluster as follows:
+
+```bash
+bash scripts/get-kubeconfig,sh
+```
+
+You can now use this `kubeconfig` as-is. E.g:
+
+```bash
+kubectl --kubeconfig=kubeconfig get nodes
+
+kubectl --kubeconfig=kubeconfig get pods -A
+```
+
+Alternatively, you can set the `KUBECONFIG` environment variable:
+
+```bash
+export KUBECONFIG=~/path/to/this/repo/relative/to/home/directory/kubeconfig
+```
+
+Then you can do:
+
+```bash
+kubectl get nodes
+kubectl get pods -A
+```
+
+> [!IMPORTANT]
+>
+> Don't get confused between the management and workload clusters if setting the
+> `KUBECONFIG` environment variable. You would need to `unset KUBECONFIG` if
+> wanting to go back to the management cluster
+
+Alternatively, you can merge the `kubeconfig` file in with the main
+`~/.kube/kubconfig` file and use `kubectl` contexts to switch between clusters
+
+### Teardown
+
+To teardown, assume the `kubeconfig`/context of the management cluster and run:
+
+```bash
+bash scripts/teardown.sh
+```
+
+Note, this does not tear down the management cluster itself. As it is simply a
+local Kind cluster, you can run:
+
+```bash
+kind delete cluster
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Talos Proxmox CAPI Homelab

--- a/controlplane/cluster.yaml
+++ b/controlplane/cluster.yaml
@@ -1,0 +1,14 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: aliktb-dev-cluster
+  namespace: default
+spec:
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    kind: TalosControlPlane
+    name: aliktb-dev-talos-cp
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: ProxmoxCluster
+    name: aliktb-proxmox-cluster

--- a/controlplane/cp-machine-template.yaml
+++ b/controlplane/cp-machine-template.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   template:
     spec:
+      checks:
+        skipCloudInitStatus: true
       disks:
         bootVolume:
           disk: scsi0

--- a/controlplane/cp-machine-template.yaml
+++ b/controlplane/cp-machine-template.yaml
@@ -12,9 +12,12 @@ spec:
           sizeGb: 32
       format: qcow2
       full: true
+      memoryMiB: 4096
       network:
         default:
           bridge: vmbr0
           model: virtio
+      numCores: 2
+      numSockets: 1
       sourceNode: gemini
       templateID: 125

--- a/controlplane/cp-machine-template.yaml
+++ b/controlplane/cp-machine-template.yaml
@@ -12,5 +12,9 @@ spec:
           sizeGb: 32
       format: qcow2
       full: true
+      network:
+        default:
+          bridge: vmbr0
+          model: virtio
       sourceNode: gemini
       templateID: 125

--- a/controlplane/cp-machine-template.yaml
+++ b/controlplane/cp-machine-template.yaml
@@ -15,6 +15,8 @@ spec:
       format: qcow2
       full: true
       memoryMiB: 4096
+      metadataSettings:
+        providerIDInjection: true
       network:
         default:
           bridge: vmbr0

--- a/controlplane/cp-machine-template.yaml
+++ b/controlplane/cp-machine-template.yaml
@@ -3,3 +3,9 @@ kind: ProxmoxMachineTemplate
 metadata:
   name: aliktb-dev-cp
   namespace: default
+spec:
+  template:
+    spec:
+      full: true
+      sourceNode: gemini
+      templateID: 125

--- a/controlplane/cp-machine-template.yaml
+++ b/controlplane/cp-machine-template.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   template:
     spec:
+      disks:
+        bootVolume:
+          disk: scsi0
+          sizeGb: 32
+      format: qcow2
       full: true
       sourceNode: gemini
       templateID: 125

--- a/controlplane/cp-machine-template.yaml
+++ b/controlplane/cp-machine-template.yaml
@@ -1,0 +1,5 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: ProxmoxMachineTemplate
+metadata:
+  name: aliktb-dev-cp
+  namespace: default

--- a/controlplane/kustomization.yaml
+++ b/controlplane/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- proxmox-cluster.yaml

--- a/controlplane/kustomization.yaml
+++ b/controlplane/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - proxmox-cluster.yaml
 - cp-machine-template.yaml
 - talos-control-plane.yaml
+- cluster.yaml

--- a/controlplane/kustomization.yaml
+++ b/controlplane/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - proxmox-cluster.yaml
 - cp-machine-template.yaml
+- talos-control-plane.yaml

--- a/controlplane/kustomization.yaml
+++ b/controlplane/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - proxmox-cluster.yaml
+- cp-machine-template.yaml

--- a/controlplane/proxmox-cluster.yaml
+++ b/controlplane/proxmox-cluster.yaml
@@ -7,6 +7,8 @@ spec:
   controlPlaneEndpoint:
     host: 192.168.0.102
     port: 6443
+  credentialsRef:
+    name: "proxmox-credentials"
   dnsServers:
   - 8.8.8.8
   - 8.8.4.4

--- a/controlplane/proxmox-cluster.yaml
+++ b/controlplane/proxmox-cluster.yaml
@@ -7,3 +7,6 @@ spec:
   controlPlaneEndpoint:
     host: 192.168.0.102
     port: 6443
+  dnsServers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/controlplane/proxmox-cluster.yaml
+++ b/controlplane/proxmox-cluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: ProxmoxCluster
+metadata:
+  name: aliktb-proxmox-cluster
+  namespace: default

--- a/controlplane/proxmox-cluster.yaml
+++ b/controlplane/proxmox-cluster.yaml
@@ -16,3 +16,5 @@ spec:
     gateway: 192.168.0.1
     prefix: 24
     metric: 1
+  schedulerHints:
+    memoryAdjustment: 0

--- a/controlplane/proxmox-cluster.yaml
+++ b/controlplane/proxmox-cluster.yaml
@@ -10,3 +10,9 @@ spec:
   dnsServers:
   - 8.8.8.8
   - 8.8.4.4
+  ipv4Config:
+    addresses:
+    - 192.168.0.105-192.168.0.115
+    gateway: 192.168.0.1
+    prefix: 24
+    metric: 1

--- a/controlplane/proxmox-cluster.yaml
+++ b/controlplane/proxmox-cluster.yaml
@@ -3,3 +3,7 @@ kind: ProxmoxCluster
 metadata:
   name: aliktb-proxmox-cluster
   namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: 192.168.0.102
+    port: 6443

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -29,6 +29,24 @@ spec:
           path: /machine/kubelet/extraArgs
           value:
             cloud-provider: external
+        - op: add
+          path: /cluster/externalCloudProvider
+          value:
+            enabled: true
+            manifests:
+            - https://raw.githubusercontent.com/siderolabs/talos-cloud-controller-manager/main/docs/deploy/cloud-controller-manager.yml
+            - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml
+        - op: add
+          path: /machine/kubelet/extraArgs/rotate-server-certificates
+          value: "true"
+        - op: add
+          path: /machine/features/kubernetesTalosAPIAccess
+          value:
+            enabled: true
+            allowedRoles:
+            - os:reader
+            allowedKubernetesNamespaces:
+            - kube-system
   infrastructureTemplate:
     kind: ProxmoxMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -14,6 +14,10 @@ spec:
           value:
             disk: /dev/sda
             image: factory.talos.dev/nocloud-installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:v1.11.1
+        - op: add
+          path: /machine/install/extraKernelArgs
+          value:
+          - net.ifnames=0
   infrastructureTemplate:
     kind: ProxmoxMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -7,6 +7,12 @@ spec:
     controlplane:
       generateType: controlplane
       talosVersion: v1.11
+      strategicPatches:
+      - |
+        - op: replace
+          path: /machine/install
+          value:
+            disk: /dev/sda
   infrastructureTemplate:
     kind: ProxmoxMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -52,4 +52,5 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
     name: aliktb-dev-cp
     namespace: default
+  replicas: 3
   version: v1.34.0

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -18,6 +18,13 @@ spec:
           path: /machine/install/extraKernelArgs
           value:
           - net.ifnames=0
+        - op: add
+          path: /machine/network/interfaces
+          value:
+          - interface: eth0
+            dhcp: false
+            vip:
+              ip: 192.168.0.102
   infrastructureTemplate:
     kind: ProxmoxMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -1,0 +1,4 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: TalosControlPlane
+metadata:
+  name: aliktb-dev-talos-cp

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -3,6 +3,10 @@ kind: TalosControlPlane
 metadata:
   name: aliktb-dev-talos-cp
 spec:
+  controlPlaneConfig:
+    controlplane:
+      generateType: controlplane
+      talosVersion: v1.11
   infrastructureTemplate:
     kind: ProxmoxMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -3,4 +3,9 @@ kind: TalosControlPlane
 metadata:
   name: aliktb-dev-talos-cp
 spec:
+  infrastructureTemplate:
+    kind: ProxmoxMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    name: aliktb-dev-cp
+    namespace: default
   version: v1.34.0

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -25,6 +25,10 @@ spec:
             dhcp: false
             vip:
               ip: 192.168.0.102
+        - op: add
+          path: /machine/kubelet/extraArgs
+          value:
+            cloud-provider: external
   infrastructureTemplate:
     kind: ProxmoxMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -2,3 +2,5 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: TalosControlPlane
 metadata:
   name: aliktb-dev-talos-cp
+spec:
+  version: v1.34.0

--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -13,6 +13,7 @@ spec:
           path: /machine/install
           value:
             disk: /dev/sda
+            image: factory.talos.dev/nocloud-installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:v1.11.1
   infrastructureTemplate:
     kind: ProxmoxMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,6 +6,7 @@ generatorOptions:
     platform.ionos.com/secret-type: "proxmox-credentials"
 resources:
 - controlplane
+- worker
 secretGenerator:
 - name: proxmox-credentials
   envs:

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,4 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    platform.ionos.com/secret-type: "proxmox-credentials"
 resources:
 - controlplane
+secretGenerator:
+- name: proxmox-credentials
+  envs:
+  - proxmox.env

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- controlplane

--- a/proxmox.env.example
+++ b/proxmox.env.example
@@ -1,0 +1,3 @@
+secret=XXXX
+token=capmox@pve!capi
+url=https://1.2.3.4:8006

--- a/scripts/get-kubeconfig.sh
+++ b/scripts/get-kubeconfig.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+kubectl get secret aliktb-dev-cluster-kubeconfig -o yaml | yq .data.value | base64 -d > kubeconfig

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+kind create cluster
+
+clusterctl init --infrastructure proxmox --ipam in-cluster --control-plane talos --bootstrap talos
+
+# Wait for everything to be ready
+kubectl -n cabpt-system rollout status deployment cabpt-controller-manager --watch --timeout=300s
+kubectl -n cacppt-system rollout status deployment cacppt-controller-manager --watch --timeout=300s
+kubectl -n capmox-system rollout status deployment capmox-controller-manager --watch --timeout=300s
+kubectl -n capi-system rollout status deployment capi-controller-manager --watch --timeout=300s
+kubectl -n capi-ipam-in-cluster-system rollout status deployment capi-ipam-in-cluster-controller-manager --watch --timeout=300s
+
+kustomize build . | kubectl apply -f -

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+kubectl delete cluster aliktb-dev-cluster

--- a/worker/kustomization.yaml
+++ b/worker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- worker-machine-template.yaml

--- a/worker/kustomization.yaml
+++ b/worker/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - worker-machine-template.yaml
+- talos-worker.yaml

--- a/worker/kustomization.yaml
+++ b/worker/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - worker-machine-template.yaml
 - talos-worker.yaml
+- worker-machine-deployment.yaml

--- a/worker/talos-worker.yaml
+++ b/worker/talos-worker.yaml
@@ -5,5 +5,10 @@ metadata:
 spec:
   template:
     spec:
+      configPatches:
+      - op: replace
+        path: /machine/install
+        value:
+          disk: /dev/sda
       generateType: worker
       talosVersion: v1.11

--- a/worker/talos-worker.yaml
+++ b/worker/talos-worker.yaml
@@ -11,5 +11,9 @@ spec:
         value:
           disk: /dev/sda
           image: factory.talos.dev/nocloud-installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:v1.11.1
+      - op: add
+        path: /machine/kubelet/extraArgs
+        value:
+          cloud-provider: external
       generateType: worker
       talosVersion: v1.11

--- a/worker/talos-worker.yaml
+++ b/worker/talos-worker.yaml
@@ -6,3 +6,4 @@ spec:
   template:
     spec:
       generateType: worker
+      talosVersion: v1.11

--- a/worker/talos-worker.yaml
+++ b/worker/talos-worker.yaml
@@ -15,5 +15,8 @@ spec:
         path: /machine/kubelet/extraArgs
         value:
           cloud-provider: external
+      - op: add
+        path: /machine/kubelet/extraArgs/rotate-server-certificates
+        value: "true"
       generateType: worker
       talosVersion: v1.11

--- a/worker/talos-worker.yaml
+++ b/worker/talos-worker.yaml
@@ -10,5 +10,6 @@ spec:
         path: /machine/install
         value:
           disk: /dev/sda
+          image: factory.talos.dev/nocloud-installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:v1.11.1
       generateType: worker
       talosVersion: v1.11

--- a/worker/talos-worker.yaml
+++ b/worker/talos-worker.yaml
@@ -1,0 +1,8 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: TalosConfigTemplate
+metadata:
+  name: aliktb-dev-talosconfig-workers
+spec:
+  template:
+    spec:
+      generateType: worker

--- a/worker/worker-machine-deployment.yaml
+++ b/worker/worker-machine-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: aliktb-dev-talos-worker
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: aliktb-dev-cluster
+spec:
+  clusterName: aliktb-dev-cluster
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: aliktb-dev-cluster
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: TalosConfigTemplate
+          name: aliktb-dev-talosconfig-workers
+      clusterName: aliktb-dev-cluster
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: ProxmoxMachineTemplate
+        name: aliktb-dev-worker
+      version: v1.34.0

--- a/worker/worker-machine-deployment.yaml
+++ b/worker/worker-machine-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: aliktb-dev-cluster
 spec:
   clusterName: aliktb-dev-cluster
+  replicas: 3
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: aliktb-dev-cluster

--- a/worker/worker-machine-template.yaml
+++ b/worker/worker-machine-template.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   template:
     spec:
+      checks:
+        skipCloudInitStatus: true
       disks:
         bootVolume:
           disk: scsi0

--- a/worker/worker-machine-template.yaml
+++ b/worker/worker-machine-template.yaml
@@ -12,9 +12,12 @@ spec:
           sizeGb: 80
       format: qcow2
       full: true
+      memoryMiB: 16384
       network:
         default:
           bridge: vmbr0
           model: virtio
+      numCores: 2
+      numSockets: 1
       sourceNode: gemini
       templateID: 125

--- a/worker/worker-machine-template.yaml
+++ b/worker/worker-machine-template.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   template:
     spec:
+      disks:
+        bootVolume:
+          disk: scsi0
+          sizeGb: 80
+      format: qcow2
       full: true
       sourceNode: gemini
       templateID: 125

--- a/worker/worker-machine-template.yaml
+++ b/worker/worker-machine-template.yaml
@@ -3,3 +3,9 @@ kind: ProxmoxMachineTemplate
 metadata:
   name: aliktb-dev-worker
   namespace: default
+spec:
+  template:
+    spec:
+      full: true
+      sourceNode: gemini
+      templateID: 125

--- a/worker/worker-machine-template.yaml
+++ b/worker/worker-machine-template.yaml
@@ -12,5 +12,9 @@ spec:
           sizeGb: 80
       format: qcow2
       full: true
+      network:
+        default:
+          bridge: vmbr0
+          model: virtio
       sourceNode: gemini
       templateID: 125

--- a/worker/worker-machine-template.yaml
+++ b/worker/worker-machine-template.yaml
@@ -1,0 +1,5 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: ProxmoxMachineTemplate
+metadata:
+  name: aliktb-dev-worker
+  namespace: default

--- a/worker/worker-machine-template.yaml
+++ b/worker/worker-machine-template.yaml
@@ -15,6 +15,8 @@ spec:
       format: qcow2
       full: true
       memoryMiB: 16384
+      metadataSettings:
+        providerIDInjection: true
       network:
         default:
           bridge: vmbr0


### PR DESCRIPTION
# Description

This change creates the initial config for Cluster API (CAPI) to bootstrap a Talos Cluster onto a Proxmox machine, with 3 control plane nodes and 3 worker nodes, all abstracted as VMs (on the same physical machine sadly :cry:)

## Credits

This has been heavily inspired by https://github.com/une-tasse-de-cafe/capi-talos-proxmox after going through the article https://a-cup-of.coffee/blog/talos-capi-proxmox/

Credits go to @qjoly for his work

## Future work

Future improvements to this repo include:

- Utilising FluxCD to automate the deployment to the management cluster of both the CAPI operator, as well as the CAPI custom resources for the workload cluster
- Creating the management cluster off the local machine e.g. as a separate 1-node Kubernetes cluster in a Proxmox VM
- Using Kustomize to create a base cluster and introduce overlays to create clusters for different environments (e.g. dev/prod clusters)
  - With dev clusters even being on newer Kubernetes/Talos versions compared to prod)
  - Consider how to automate ephemeral clusters e.g. for CI pipelines. Alternatively, this may end up being done with vCluster