### PR TITLE
Enable NetworkPolicy rules with Calico + Flannel (Canal)

### DIFF
--- a/controlplane/talos-control-plane.yaml
+++ b/controlplane/talos-control-plane.yaml
@@ -37,6 +37,10 @@ spec:
             - https://raw.githubusercontent.com/siderolabs/talos-cloud-controller-manager/main/docs/deploy/cloud-controller-manager.yml
             - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml
         - op: add
+          path: /cluster/extraManifests
+          value:
+          - https://raw.githubusercontent.com/projectcalico/calico/v3.30.3/manifests/canal.yaml
+        - op: add
           path: /machine/kubelet/extraArgs/rotate-server-certificates
           value: "true"
         - op: add

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -11,4 +11,12 @@ kubectl -n capmox-system rollout status deployment capmox-controller-manager --w
 kubectl -n capi-system rollout status deployment capi-controller-manager --watch --timeout=300s
 kubectl -n capi-ipam-in-cluster-system rollout status deployment capi-ipam-in-cluster-controller-manager --watch --timeout=300s
 
+# Deploy cluster
 kustomize build . | kubectl apply -f -
+
+# Wait for control plane to be ready
+echo "Waiting for control plane to be ready. This may take up to 10 mins..."
+kubectl wait taloscontrolplane.controlplane.cluster.x-k8s.io/aliktb-dev-talos-cp --for=condition=Ready=true --timeout=10m
+
+# Extract workload cluster Kubeconfig file
+bash scripts/get-kubeconfig.sh


### PR DESCRIPTION
# Description

The default CNI, [Flannel](https://github.com/flannel-io/flannel) that ships with Talos Linux does not natively support the `NetworkPolicy` resource. Whilst it can be applied to a cluster being a native Kubernetes resource, the Flannel CNI will not perform any action on any deployed `NetworkPolicy`

More sophisticated CNIs such as Calico and Cillium include a larger set of features, one of them being support for `NetworkPolicy`s to define traffic rules. The deployment of these CNIs is a little bit complicated, with documentation for Cillum + Talos being documented [HERE](https://www.talos.dev/v1.11/kubernetes-guides/network/deploying-cilium/). There appear to be limitations with the installation applying manifests with sensitive information, so it is recommended __not__ to put the Talos machine config patch into source control. Other methods such as using `Helm` also add complexity as this step would need to be done outside of Cluster API. As this config is designed to be simple to deploy (for myself), going down that route also isn't favourable

## Solution

Thankfully, Calico supports a "Policy Mode" as seen in the documentation [HERE](https://docs.tigera.io/calico/latest/getting-started/kubernetes/flannel/install-for-flannel). This will use Flannel as the CNI, but Calico will enforce the rules defined in any `NetworkPolicy` in a "CNI" called Canal (a [portmanteau of the 2 CNI names](https://ubuntu.com/kubernetes/charmed-k8s/docs/cni-canal)). This is deployed using [cluster.extraManifests](https://www.talos.dev/v1.11/kubernetes-guides/configuration/inlinemanifests/#extramanifests). This keeps the overall config/provisioning process within Cluster API and keeps things simple, whilst support `NetworkPolicy`s

### Extra note

The `scripts/init.sh` script now waits for the control plane to be ready and automatically extracts the workload cluster's Kubeconfig from the Kubernetes secret of the management cluster